### PR TITLE
Don't save intermediate latex files in repo root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
-OUT_DIR := build/
+BUILD_DIR := build/
+OUT_DIR := out/
 FILES := $(wildcard *.tex)
 
 # Compile LaTeX with jobname and environment variables
@@ -8,7 +9,8 @@ FILES := $(wildcard *.tex)
 # $3: environment variables
 # $4: directory to compile in
 define compile_latex_with_jobname_and_env
-	cd $(4) && $(3) latexmk --shell-escape -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=$(OUT_DIR) -jobname=$(2) "$(1)"
+	@mkdir -p $(BUILD_DIR)
+	cd $(4) && $(3) latexmk --shell-escape -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=$(BUILD_DIR) -jobname=$(2) "$(1)"
 endef
 
 # Build LaTeX with jobname and environment variables, compile and copy to output directory
@@ -22,7 +24,7 @@ define build_latex_with_jobname_and_env
 	@$(call compile_latex_with_jobname_and_env,$(FILE),$(2),$(3),$(DIR))
 	@echo -e "\e[1;32mSuccessfully compiled \"$(FILE)\" in \"$(DIR)\" with jobname \"$(2)\"$<\e[0m"
 	@mkdir -p $(OUT_DIR)
-	@cp $(OUT_DIR)/$(2).pdf $(DIR)/
+	@cp $(BUILD_DIR)/$(2).pdf $(OUT_DIR)/
 endef
 
 all:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ FILES := $(wildcard *.tex)
 # $3: environment variables
 # $4: directory to compile in
 define compile_latex_with_jobname_and_env
-	cd $(4) && $(3) latexmk --shell-escape -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -jobname=$(2) "$(1)"
+	cd $(4) && $(3) latexmk --shell-escape -synctex=1 -interaction=nonstopmode -file-line-error -lualatex -outdir=$(OUT_DIR) -jobname=$(2) "$(1)"
 endef
 
 # Build LaTeX with jobname and environment variables, compile and copy to output directory
@@ -22,7 +22,7 @@ define build_latex_with_jobname_and_env
 	@$(call compile_latex_with_jobname_and_env,$(FILE),$(2),$(3),$(DIR))
 	@echo -e "\e[1;32mSuccessfully compiled \"$(FILE)\" in \"$(DIR)\" with jobname \"$(2)\"$<\e[0m"
 	@mkdir -p $(OUT_DIR)
-	@cp $(DIR)/$(2).pdf $(OUT_DIR)/
+	@cp $(OUT_DIR)/$(2).pdf $(DIR)/
 endef
 
 all:


### PR DESCRIPTION
No files are save in the repo root. Makes navigation easier, keeps things cleaner.
The `build` dir is used for intermediate files similar to how c projects are build.
Lastly, wo copy into `out` because this way, there arent 4 files with the same name. Again, this is less cognitive load when navigating the files.